### PR TITLE
feature/#137

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -43,13 +43,13 @@ func getCommand(cmd *cobra.Command, args []string) error {
 		}
 	}
 	service := cfg.FindServiceByName(args[0])
-	details, err := details.GetServiceDetails(cfg, service)
+	d, err := details.GetServiceDetails(cfg, service)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if tmpl != nil {
-		err = tmpl.Execute(os.Stdout, details)
+		err = tmpl.Execute(os.Stdout, d)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
@@ -57,7 +57,7 @@ func getCommand(cmd *cobra.Command, args []string) error {
 	} else {
 		output := util.FormatTable([][]string{
 			{"NAME", "HOSTNAME", "CLUSTER-IP"},
-			{details.Name, details.Hostname, details.ClusterIP},
+			{d.Name, d.Hostname, d.ClusterIP},
 		})
 		fmt.Print(output)
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -18,7 +18,7 @@ func newGetCli() *cobra.Command {
 		Long:  "Print a detailed description of the selected resources, including related resources such as hostname or host IP.",
 		RunE:  getCommand,
 	}
-	getCmd.PersistentFlags().StringP("format", "", "", "Return specified format")
+	getCmd.PersistentFlags().StringP("output", "o", "", "Go template string")
 	return getCmd
 }
 
@@ -33,31 +33,31 @@ func getCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	var tmpl *template.Template
-	if cmd.Flags().Changed("format") {
-		var format string
-		format, _ = cmd.Flags().GetString("format")
-		tmpl, err = template.New("test").Parse(format)
+	if cmd.Flags().Changed("output") {
+		var output string
+		output, _ = cmd.Flags().GetString("output")
+		tmpl, err = template.New("test").Parse(output)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}
 	service := cfg.FindServiceByName(args[0])
-	result, err := details.GetServiceDetails(cfg, service)
+	details, err := details.GetServiceDetails(cfg, service)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if tmpl != nil {
-		err = tmpl.Execute(os.Stdout, result)
+		err = tmpl.Execute(os.Stdout, details)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	} else {
 		output := util.FormatTable([][]string{
-			{"NAME", "NAMESPACE", "HOSTNAME", "CLUSTER-IP"},
-			{result.Service, result.Namespace, result.Hostname, result.ClusterIP},
+			{"NAME", "HOSTNAME", "CLUSTER-IP"},
+			{details.Name, details.Hostname, details.ClusterIP},
 		})
 		fmt.Print(output)
 	}

--- a/internal/app/get/get.go
+++ b/internal/app/get/get.go
@@ -16,10 +16,9 @@ type getRunner struct {
 }
 
 type ServiceDetails struct {
-	Service   string
-	Hostname  string
-	Namespace string
+	Name      string
 	ClusterIP string
+	Hostname  string
 }
 
 func GetServiceDetails(cfg *config.Config, service *config.Service) (*ServiceDetails, error) {
@@ -50,11 +49,10 @@ func (g *getRunner) run() (*ServiceDetails, error) {
 	if err != nil {
 		return nil, err
 	}
-	composeService := &ServiceDetails{
-		Service:   result.Name,
+	details := &ServiceDetails{
+		Name:      g.service.Name,
 		Hostname:  result.Name + "." + result.Namespace + ".svc.cluster.local",
-		Namespace: result.Namespace,
 		ClusterIP: result.Spec.ClusterIP,
 	}
-	return composeService, nil
+	return details, nil
 }

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    entrypoint: ["/bin/bash", "-c", "STOP=0; trap 'STOP=1' INT; while [[ $$STOP -eq 0 ]]; do sleep 1; done"]
+    entrypoint: ["/bin/bash", "-c", "STOP=0; trap 'STOP=1' INT; while [[ $$STOP -eq 0 ]]; do sleep 1; echo 'heartbeat'; done"]
     environment:
     - ASDF=10
     - DB_URL=postgresql://db:5432
@@ -21,9 +21,12 @@ services:
     environment:
       ENVVAR_EXTENDS: test
     ports:
-      - 8235:8234
+      - 8236:8234
   permission-service:
-    entrypoint: ["/bin/bash", "-c", "STOP=0; trap 'STOP=1' INT; while [[ $$STOP -eq 0 ]]; do sleep 1; done"]
+    entrypoint: ["/bin/bash", "-c", "STOP=0; trap 'STOP=1' INT; while [[ $$STOP -eq 0 ]]; do sleep 1; echo 'heartbeat'; done"]
+    image: ubuntu:latest
+    extends:
+      service: generic-service
     environment:
       ENVVAR_STR: str
       ENVVAR_INT: 23


### PR DESCRIPTION
fixes #137: rename format to output in get command for consistency with kubectl and shorthand -o, fix test docker-compose.yml, add documentation for get command